### PR TITLE
Item Proxies should always trigger block updates when contents change

### DIFF
--- a/src/main/java/org/cyclops/capabilityproxy/tileentity/TileItemCapabilityProxy.java
+++ b/src/main/java/org/cyclops/capabilityproxy/tileentity/TileItemCapabilityProxy.java
@@ -1,7 +1,10 @@
 package org.cyclops.capabilityproxy.tileentity;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import org.cyclops.capabilityproxy.block.BlockItemCapabilityProxy;
@@ -29,10 +32,21 @@ public class TileItemCapabilityProxy extends InventoryTileEntity {
 
     @Override
     public void setInventorySlotContents(int slotId, ItemStack itemstack) {
+        boolean wasEmpty = getStackInSlot(slotId).isEmpty();
         super.setInventorySlotContents(slotId, itemstack);
-        boolean isEmpty = getStackInSlot(slotId).isEmpty();
-        getWorld().setBlockState(getPos(), getWorld().getBlockState(getPos())
-             .withProperty(BlockItemCapabilityProxy.INACTIVE, isEmpty));
+        boolean isEmpty = itemstack.isEmpty();
+        
+        World world = getWorld();
+        IBlockState state = world.getBlockState(getPos());
+        if (wasEmpty != isEmpty) {
+            world.setBlockState(getPos(),
+                    state.withProperty(BlockItemCapabilityProxy.INACTIVE, isEmpty));
+        }
+        else
+        {
+            //Trigger a block update anyway, so nearby blocks can recheck capabilities.
+            world.markAndNotifyBlock(getPos(), world.getChunkFromBlockCoords(getPos()), state, state, 3);
+        }
     }
 
     protected ItemStack getContents() {

--- a/src/main/java/org/cyclops/capabilityproxy/tileentity/TileItemCapabilityProxy.java
+++ b/src/main/java/org/cyclops/capabilityproxy/tileentity/TileItemCapabilityProxy.java
@@ -45,7 +45,7 @@ public class TileItemCapabilityProxy extends InventoryTileEntity {
         else
         {
             //Trigger a block update anyway, so nearby blocks can recheck capabilities.
-            world.markAndNotifyBlock(getPos(), world.getChunkFromBlockCoords(getPos()), state, state, 3);
+            BlockHelpers.markForUpdate(world, getPos());
         }
     }
 

--- a/src/main/java/org/cyclops/capabilityproxy/tileentity/TileItemCapabilityProxy.java
+++ b/src/main/java/org/cyclops/capabilityproxy/tileentity/TileItemCapabilityProxy.java
@@ -29,13 +29,10 @@ public class TileItemCapabilityProxy extends InventoryTileEntity {
 
     @Override
     public void setInventorySlotContents(int slotId, ItemStack itemstack) {
-        boolean wasEmpty = getStackInSlot(slotId).isEmpty();
         super.setInventorySlotContents(slotId, itemstack);
-        boolean isEmpty = itemstack.isEmpty();
-        if (wasEmpty != isEmpty) {
-            getWorld().setBlockState(getPos(), getWorld().getBlockState(getPos())
-                    .withProperty(BlockItemCapabilityProxy.INACTIVE, isEmpty));
-        }
+        boolean isEmpty = getStackInSlot(slotId).isEmpty();
+        getWorld().setBlockState(getPos(), getWorld().getBlockState(getPos())
+             .withProperty(BlockItemCapabilityProxy.INACTIVE, isEmpty));
     }
 
     protected ItemStack getContents() {


### PR DESCRIPTION
In their current state, Item Capability Proxies can confuse other mods by changing capabilities without notifying them. An obvious consequence of this is that pipes and wires won't connect to the block unless an appropriate item is already inside. I've also found that if you place a battery in an Item Proxy and connect Ender IO conduits to it, the conduits will keep trying to charge the item even after the item is removed. (The item doesn't actually charge, but the power is wasted because the conduit thinks the block can still accept power.)

I think a simple solution is to simply trigger block updates when the block changes. This will ensure that nearby blocks get a chance to check for the new state of the block.