### PR TITLE
Fix Stack Overflow in ranged proxy

### DIFF
--- a/src/main/java/org/cyclops/capabilityproxy/block/BlockRangedCapabilityProxy.java
+++ b/src/main/java/org/cyclops/capabilityproxy/block/BlockRangedCapabilityProxy.java
@@ -56,7 +56,6 @@ public class BlockRangedCapabilityProxy extends BlockTile {
                                     BlockRayTraceResult hit) {
         RecursiveHit rhit = hit instanceof RecursiveHit ? (RecursiveHit)hit : new RecursiveHit(hit, new HashSet<>(), hit.getPos(), hit.getFace());
         if (rhit.chain.contains(pos)) {
-            System.out.println("Recursive Found: " + rhit.chain + " " + pos);
             rhit.setFailed();
             return false;
         }

--- a/src/main/java/org/cyclops/capabilityproxy/tileentity/TileCapabilityProxy.java
+++ b/src/main/java/org/cyclops/capabilityproxy/tileentity/TileCapabilityProxy.java
@@ -55,6 +55,6 @@ public class TileCapabilityProxy extends CyclopsTileEntity {
         handling = true;
         LazyOptional<T> ret = getTarget(capability, facing);
         handling = false;
-        return ret;
+        return ret == null ? LazyOptional.empty() : ret;
     }
 }

--- a/src/main/java/org/cyclops/capabilityproxy/tileentity/TileRangedCapabilityProxy.java
+++ b/src/main/java/org/cyclops/capabilityproxy/tileentity/TileRangedCapabilityProxy.java
@@ -31,7 +31,7 @@ public class TileRangedCapabilityProxy extends TileCapabilityProxy {
                 return instance;
             }
         }
-        return null;
+        return LazyOptional.empty();
     }
 
     @Override


### PR DESCRIPTION
Using a Block level field is just asking for concurrency issues. So pass the stack in via the Raytrace value.

Also, fixed NPE that you cause in other mods by returning null from getCapability/getTarget.